### PR TITLE
Change publish method do match repo elastic/beat

### DIFF
--- a/beat/journalbeat.go
+++ b/beat/journalbeat.go
@@ -191,7 +191,7 @@ func (jb *Journalbeat) seekToPosition() error {
 // Setup prepares Journalbeat for the main loop (starts journalreader, etc.)
 func (jb *Journalbeat) Setup(b *beat.Beat) error {
 	logp.Info("Journalbeat Setup")
-	jb.output = b.Events
+	jb.output = b.Publisher.Connect()
 	jb.done = make(chan int)
 	jb.recv = make(chan sdjournal.JournalEntry)
 	jb.cursorChan = make(chan string)


### PR DESCRIPTION
Object libbeat/beat/beat.go:Beat has been modified. (commit 57477cf12ef53f0fcdc33757197fa7243bdd2584 on elastic/beats repo).
Adapts journalbeat output to work accordingly.
