### PR TITLE
Added more configuration control over cursor seeking

### DIFF
--- a/beat/config.go
+++ b/beat/config.go
@@ -23,9 +23,8 @@ type JournalReaderConfig struct {
 	WriteCursorState     *bool          `config:"write_cursor_state"`
 	CursorStateFile      *string        `config:"cursor_state_file"`
 	FlushCursorSecs      *int           `config:"flush_cursor_secs"`
-	SeekToCursor         *bool          `config:"seek_to_cursor"`
-	SeekToHead           *bool          `config:"seek_to_head"`
-	SeekToTail           *bool          `config:"seek_to_tail"`
+	SeekPosition         *string        `config:"seek_position"`
+	CursorSeekFallback   *string        `config:"cursor_seek_fallback"`
 	ConvertToNumbers     *bool          `config:"convert_to_numbers"`
 	CleanFieldNames      *bool          `config:"clean_field_names"`
 	MoveMetadataLocation *string        `config:"move_metadata_to_field"`

--- a/etc/journalbeat.yml
+++ b/etc/journalbeat.yml
@@ -2,12 +2,19 @@ shipper:
   name: journalbeat
   #tags: [ "blue", "red" ]
 input:
+  # What position in journald to seek to at start up
+  # options: cursor, tail, head (defaults to tail)
+  seek_position: cursor
+
+  # If seek_position is set to cursor and seeking to cursor fails
+  # fall back to this method.  If set to none will it will exit
+  # options: tail, head, none (defaults to tail)
+  cursor_seek_fallback: tail
+
   write_cursor_state: true
   cursor_state_file: /tmp/journalbeat-cursor-state
   flush_cursor_secs: 3
-  seek_to_cursor: true
-  seek_to_head: false
-  seek_to_tail: true
+
   clean_field_names: true
   convert_to_numbers: false
   move_metadata_to_field: journal


### PR DESCRIPTION
I found the separate flags for each type of seek confusing and it also didn't allow for control over the fallback method if cursor seek failed.  There are instances, such as first run, that loading the cursor would fail and one would want it to seek to head instead of tail.  Other times one might want it to fail completely if seeking from cursor fails.  It also allowed for configurations that didn't make sense (all true).

This pull request switches to using seek_position instead of separate flags and adds a cursor_seek_fallback option.
