### PR TITLE
Add option "units" to monitor only specified systemd units

### DIFF
--- a/beat/config.go
+++ b/beat/config.go
@@ -25,6 +25,7 @@ type JournalReaderConfig struct {
 	CleanFieldNames      *bool   `config:"clean_field_names"`
 	MoveMetadataLocation *string `config:"move_metadata_to_field"`
 	DefaultType          *string `config:"default_type"`
+	Unit                 *string `config:"unit"`
 }
 
 // ConfigSettings holds JournalConfig at the Input section of the config file

--- a/beat/config.go
+++ b/beat/config.go
@@ -16,16 +16,16 @@ package beat
 
 // JournalReaderConfig provides the config settings for the journald reader
 type JournalReaderConfig struct {
-	WriteCursorState     *bool   `config:"write_cursor_state"`
-	CursorStateFile      *string `config:"cursor_state_file"`
-	FlushCursorSecs      *int    `config:"flush_cursor_secs"`
-	SeekPosition         *string `config:"seek_position"`
-	CursorSeekFallback   *string `config:"cursor_seek_fallback"`
-	ConvertToNumbers     *bool   `config:"convert_to_numbers"`
-	CleanFieldNames      *bool   `config:"clean_field_names"`
-	MoveMetadataLocation *string `config:"move_metadata_to_field"`
-	DefaultType          *string `config:"default_type"`
-	Unit                 *string `config:"unit"`
+	WriteCursorState     *bool     `config:"write_cursor_state"`
+	CursorStateFile      *string   `config:"cursor_state_file"`
+	FlushCursorSecs      *int      `config:"flush_cursor_secs"`
+	SeekPosition         *string   `config:"seek_position"`
+	CursorSeekFallback   *string   `config:"cursor_seek_fallback"`
+	ConvertToNumbers     *bool     `config:"convert_to_numbers"`
+	CleanFieldNames      *bool     `config:"clean_field_names"`
+	MoveMetadataLocation *string   `config:"move_metadata_to_field"`
+	DefaultType          *string   `config:"default_type"`
+	Units                *[]string `config:"units"`
 }
 
 // ConfigSettings holds JournalConfig at the Input section of the config file

--- a/beat/journalbeat.go
+++ b/beat/journalbeat.go
@@ -50,6 +50,7 @@ type Journalbeat struct {
 	cleanFieldnames      bool
 	moveMetadataLocation string
 	defaultType          string
+	unit                 string
 
 	jr   *sdjournal.JournalReader
 	done chan int
@@ -130,6 +131,12 @@ func (jb *Journalbeat) Config(b *beat.Beat) error {
 		jb.defaultType = "journal"
 	}
 
+	if jb.JbConfig.Input.Unit != nil {
+		jb.unit = *jb.JbConfig.Input.Unit
+	} else {
+		jb.unit = ""
+	}
+
 	if _, ok := SeekPositions[jb.seekPosition]; !ok {
 		errMsg := "seek_position must be either cursor, head, or tail"
 		logp.Err(errMsg)
@@ -186,9 +193,30 @@ func seekToHelper(position string, err error) error {
 	return err
 }
 
+func (jb *Journalbeat) readerConfig() sdjournal.JournalReaderConfig {
+	if jb.unit != "" {
+		return sdjournal.JournalReaderConfig{
+			Since: time.Duration(1),
+			Matches: []sdjournal.Match{
+				{
+					Field: sdjournal.SD_JOURNAL_FIELD_SYSTEMD_UNIT,
+					Value: jb.unit,
+				},
+			},
+		}
+	}
+
+	return sdjournal.JournalReaderConfig{
+		Since: time.Duration(1),
+	}
+}
+
 // Setup prepares Journalbeat for the main loop (starts journalreader, etc.)
 func (jb *Journalbeat) Setup(b *beat.Beat) error {
 	logp.Info("Journalbeat Setup")
+
+	var readerConfig = jb.readerConfig()
+
 	jb.output = b.Publisher.Connect()
 	// Buffer channel else write to it blocks when Stop is called while
 	// FollowJournal waits to write next  event
@@ -197,10 +225,7 @@ func (jb *Journalbeat) Setup(b *beat.Beat) error {
 	jb.cursorChan = make(chan string)
 	jb.cursorChanFlush = make(chan int)
 
-	jr, err := sdjournal.NewJournalReader(sdjournal.JournalReaderConfig{
-		Since: time.Duration(1),
-		//          NumFromTail: 0,
-	})
+	jr, err := sdjournal.NewJournalReader(readerConfig)
 	if err != nil {
 		logp.Err("Could not create JournalReader")
 		return err

--- a/etc/journalbeat.yml
+++ b/etc/journalbeat.yml
@@ -18,8 +18,9 @@ input:
   convert_to_numbers: false
   move_metadata_to_field: journal
   #default_type: journal
-  # Specific unit to monitor
-  # unit: httpd.service
+
+  #Specific units to monitor
+  #units: ["httpd.service"]
 output:
   console:
     pretty: true

--- a/etc/journalbeat.yml
+++ b/etc/journalbeat.yml
@@ -18,6 +18,8 @@ input:
   convert_to_numbers: false
   move_metadata_to_field: journal
   #default_type: journal
+  # Specific unit to monitor
+  # unit: httpd.service
 output:
   console:
     pretty: true


### PR DESCRIPTION
Fixes #3 by providing an option matching the `journalctl -u $SERVICE` with a config option `unit: $SERVICE`.
