### PR TITLE
Add support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Makefile
+ci
+etc
+docker

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ Temporary Items
 # Build/package files
 bin/
 build/
-Dockerfile
+/Dockerfile
+/journalbeat.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+# Journalbeats Makefile
+#
+# This Makefile contains a collection of targets to help with docker image
+# maintenance and creation. Run `make docker-build` to build the docker
+# image. Run `make docker-tag` to build the image and tag the docker image
+# with the current git tag.
+#
+# Note: This Makefile can be modified to include any future non-docker build
+# tasks as well.
+
+IMAGE_NAME := journalbeat
+GIT_BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD | sed "sX/X-Xg")
+GIT_TAG_NAME := $(shell git describe --tags)
+
+TAGS := $(GIT_BRANCH_NAME) $(GIT_TAG_NAME)
+
+ifeq ($(GIT_BRANCH_NAME),master)
+  TAGS += latest
+endif
+
+TAGS := $(foreach t,$(TAGS),$(IMAGE_NAME):$(t))
+
+#
+# Clean up the project
+#
+clean:
+	rm -f Dockerfile
+	rm -f journalbeat.yml
+.PHONY: clean
+
+#
+# Copy journalbeat.yml to the main project directory
+#
+journalbeat.yml:
+	cp docker/journalbeat.yml .
+
+#
+# Copy Dockerfile to the main project directory
+#
+Dockerfile:
+	cp docker/Dockerfile .
+
+#
+# docker tag the image
+#
+docker-tag: docker-build
+	@echo $(TAGS) | xargs -n 1 docker tag $(IMAGE_NAME)
+.PHONY: docker-tag
+
+#
+# docker build the image
+#
+docker-build: Dockerfile journalbeat.yml
+	docker build -t $(IMAGE_NAME) .
+.PHONY: docker-build
+
+#
+#  show the current version and branch name, for quick reference.
+#
+version:
+	@echo Version: $(GIT_TAG_NAME)
+	@echo Branch: $(GIT_BRANCH_NAME)
+.PHONY: version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.8 
+MAINTAINER mheese
+
+RUN apt-get update && \
+    apt-get install -y pkg-config libsystemd-dev git gcc curl && \
+    apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /go/src/github.com/mheese/journalbeat && mkdir -p /data
+COPY . /go/src/github.com/mheese/journalbeat
+WORKDIR /go/src/github.com/mheese/journalbeat
+RUN go build && cp journalbeat / && cp journalbeat.yml / && rm -rf /go/src/github.com/mheese
+WORKDIR /
+
+CMD ["./journalbeat", "-e", "-c", "journalbeat.yml"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,44 @@
+# Journalbeat Docker
+
+Journalbeat can be made to run in a Docker container. This documentation goes
+over a few of the commands that can be used to manage the Docker container.s
+
+## Build Container
+
+From the main project directory, a docker container can be build like so:
+
+    $ make docker-build
+
+## Tag Container
+
+A docker container can also be built for the current git tag. If the project is
+ahead of a tag, the git describe will be used instead.  
+
+    $ make docker-tag
+
+## Cleanup
+
+To remove any temporary files created from the build process, clean can be run:
+
+    $ make clean
+
+## Running The Container
+
+Once the docker container has been built, run it like the following example:
+
+    $ docker run -e LOGSTASH_HOST=logtashhost:5044 \
+      -v /var/tmp/journalbeat:/data \
+      -v /var/log/journal:/var/log/journal \
+      -v /run/log/journal:/run/log/journal \
+      -v /etc/machine-id:/etc/machine-id \
+      --name journalbeat journalbeat
+
+Note: Journalbeat requires access to resources only available on the host machine.
+Because of this, Journalbeat only supports host machines running systemd. Make
+sure to mount `/var/log/journal`, `/run/log/journal`, and `/etc/machine-id` for
+Journalbeat to functional properly.
+
+When running with Docker, all application configuration should be set using
+environment variables. The following environment variables are setup to be respected:
+
+* LOGSTASH_HOST - The host and beat port for the logstash server. Example: 192.168.1.100:5044

--- a/docker/dockerfile.build
+++ b/docker/dockerfile.build
@@ -1,5 +1,5 @@
-FROM golang:1.8 
-MAINTAINER mheese
+FROM golang:1.8
+MAINTAINER mbrooks
 
 RUN apt-get update && \
     apt-get install -y pkg-config libsystemd-dev git gcc curl && \
@@ -8,7 +8,4 @@ RUN apt-get update && \
 RUN mkdir -p /go/src/github.com/mheese/journalbeat && mkdir -p /data
 COPY . /go/src/github.com/mheese/journalbeat
 WORKDIR /go/src/github.com/mheese/journalbeat
-RUN go build && cp journalbeat / && cp journalbeat.yml / && rm -rf /go/src/github.com/mheese
-WORKDIR /
-
-CMD ["./journalbeat", "-e", "-c", "journalbeat.yml"]
+RUN go build

--- a/docker/dockerfile.release
+++ b/docker/dockerfile.release
@@ -1,0 +1,8 @@
+FROM debian:jessie
+MAINTAINER mbrooks
+
+RUN mkdir -p /data
+WORKDIR /
+COPY journalbeat journalbeat.yml ./
+
+CMD ["./journalbeat", "-e", "-c", "journalbeat.yml"]

--- a/docker/journalbeat.yml
+++ b/docker/journalbeat.yml
@@ -1,0 +1,17 @@
+journalbeat:
+  seek_position: cursor
+  cursor_seek_fallback: tail
+  write_cursor_state: true
+  cursor_state_file: /data/journalbeat-cursor-state
+  cursor_flush_period: 5s
+  clean_field_names: true
+  convert_to_numbers: false
+  move_metadata_to_field: journal
+
+name: journalbeat
+
+output.logstash:
+  enabled: true
+  hosts: ["${LOGSTASH_HOST}"]
+
+logging.to_files: false


### PR DESCRIPTION
This commit adds basic support for docker image creation. A Dockerfile
has been added along with a Makefile that contains targets to assist
with the docker build process.

Run `make docker-build` to build the docker image. After it is built
the image can be run by executing `docker run journalbeat`. Run
`make docker-tag` to build the image and tag the docker image with the
current git tag.