### PR TITLE
Fix shutdown when the output is unavailable

### DIFF
--- a/beater/journalbeat.go
+++ b/beater/journalbeat.go
@@ -128,7 +128,6 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 func (jb *Journalbeat) Run(b *beat.Beat) error {
 	logp.Info("Journalbeat is running!")
 	defer func() {
-		jb.client.Close()
 		jb.journal.Close()
 		close(jb.cursorChan)
 		close(jb.pending)
@@ -174,4 +173,5 @@ func (jb *Journalbeat) Run(b *beat.Beat) error {
 func (jb *Journalbeat) Stop() {
 	logp.Info("Stopping Journalbeat")
 	close(jb.done)
+	jb.client.Close()
 }


### PR DESCRIPTION
When the publishing queue is full and we need to stop the beat we will get stuck in the main loop of `beater.(*Journalbeat).Run` in `libbeat/publisher.(*client).PublishEvent`.
Moving closing the publisher to the `beater.(*Journalbeat).Stop` and unblocking return from  `journal.Follow` allows to shutdown gracefully in case the output is blocked for whatever reason.