### PR TITLE
Support for docker hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # Note: This Makefile can be modified to include any future non-docker build
 # tasks as well.
 
-IMAGE_NAME := journalbeat
+IMAGE_NAME := mheese/journalbeat
 GIT_BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD | sed "sX/X-Xg")
 GIT_TAG_NAME := $(shell git describe --tags)
 
@@ -66,7 +66,7 @@ build/journalbeat.yml:
 # docker tag the image
 #
 docker-tag: docker-build
-	@echo $(TAGS) | xargs -n 1 docker tag $(IMAGE_NAME)
+	echo $(TAGS) | xargs -n 1 docker tag $(IMAGE_NAME)
 .PHONY: docker-tag
 
 #
@@ -75,6 +75,13 @@ docker-tag: docker-build
 docker-build: build build/Dockerfile build/journalbeat.yml
 	cd build && docker build -t $(IMAGE_NAME) .
 .PHONY: docker-build
+
+#
+# docker push all tags
+#
+docker-push: docker-tag
+	echo $(TAGS) | xargs -n 1 docker push
+.PHONY: docker-push
 
 #
 #  show the current version and branch name, for quick reference.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # This Makefile contains a collection of targets to help with docker image
 # maintenance and creation. Run `make docker-build` to build the docker
 # image. Run `make docker-tag` to build the image and tag the docker image
-# with the current git tag.
+# with the current git tag. Run `make docker-push` to push all tags to docker hub.
 #
 # Note: This Makefile can be modified to include any future non-docker build
 # tasks as well.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # Journalbeat Docker
 
 Journalbeat can be made to run in a Docker container. This documentation goes
-over a few of the commands that can be used to manage the Docker container.s
+over a few of the commands that can be used to manage the Docker containers.
 
 ## Build Container
 
@@ -22,23 +22,62 @@ To remove any temporary files created from the build process, clean can be run:
 
     $ make clean
 
-## Running The Container
+## How to use this image
 
-Once the docker container has been built, run it like the following example:
+### Start Journalbeat with commandline configuration
+
+Once the docker container has been built, a quick way to get Journalbeat up and
+running is to execute the command below:
 
     $ docker run -e LOGSTASH_HOST=logtashhost:5044 \
       -v /var/tmp/journalbeat:/data \
       -v /var/log/journal:/var/log/journal \
       -v /run/log/journal:/run/log/journal \
       -v /etc/machine-id:/etc/machine-id \
-      --name journalbeat journalbeat
+      --name journalbeat mheese/journalbeat
 
 Note: Journalbeat requires access to resources only available on the host machine.
 Because of this, Journalbeat only supports host machines running systemd. Make
 sure to mount `/var/log/journal`, `/run/log/journal`, and `/etc/machine-id` for
 Journalbeat to functional properly.
 
+Although it's not required, mounting the `/data` volume to the host allows for
+journal cursor data to be persistent for server reboots, docker image upgrades,
+and docker image restarts.
+
 When running with Docker, all application configuration should be set using
 environment variables. The following environment variables are setup to be respected:
 
 * LOGSTASH_HOST - The host and beat port for the logstash server. Example: 192.168.1.100:5044
+
+### Start Journalbeat with configuration file
+
+If you need to run Journalbeat with a configuration file, journalbeat.yml, that's
+located in your current directory, you can use the Journalbeat image as follows:
+
+    $ docker run -v "$PWD/journalbeat.yml":/journalbeat.yml \
+    -v /var/log/journal:/var/log/journal \
+    -v /run/log/journal:/run/log/journal \
+    -v /etc/machine-id:/etc/machine-id \
+    --name journalbeat mheese/journalbeat
+
+### Using a Dockerfile
+
+If you'd like to have a production Journalbeat image with a pre-baked configuration
+file, use of a Dockerfile is recommended:
+
+```
+FROM mheese/journalbeat
+
+COPY journalbeat.yml ./
+
+CMD ["./journalbeat", "-e", "-c", "journalbeat.yml"]
+```
+
+Then, build with `docker build -t my-journalbeat` and deploy with something like
+the following:
+
+    $ docker run -d -v /var/log/journal:/var/log/journal \
+    -v /run/log/journal:/run/log/journal \
+    -v /etc/machine-id:/etc/machine-id \
+    my-journalbeat


### PR DESCRIPTION
Previously, we didn't know what the final name of the docker image
would be named. Now we know that image will live at mheese/journalbeat.
This commit fixes the package name, as well as, provides a make target
for pushing the docker images live.