### PR TITLE
Added lz4 library

### DIFF
--- a/docker/dockerfile.release
+++ b/docker/dockerfile.release
@@ -1,6 +1,10 @@
 FROM debian:jessie
 MAINTAINER mbrooks
 
+RUN apt-get update && \
+    apt-get install -y pkg-config liblz4-1 && \
+    apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /data
 WORKDIR /
 COPY journalbeat journalbeat.yml ./


### PR DESCRIPTION
Added lz4 library to release container so that compressed journals can be read. Fixes journal log reading from containerlinux beta channel.