### PR TITLE
install ca-certificates in docker image

### DIFF
--- a/docker/dockerfile.release
+++ b/docker/dockerfile.release
@@ -2,7 +2,7 @@ FROM debian:jessie
 MAINTAINER mbrooks
 
 RUN apt-get update && \
-    apt-get install -y pkg-config liblz4-1 && \
+    apt-get install -y pkg-config liblz4-1 ca-certificates && \
     apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /data


### PR DESCRIPTION
It is necessary if configuring ssl in journalbeat.yml