### PR TITLE
Add unit matching that follows 'journalbeat -u' for config units = [ ... ]

### DIFF
--- a/beater/journalbeat.go
+++ b/beater/journalbeat.go
@@ -83,10 +83,8 @@ func (jb *Journalbeat) initJournal() error {
 	}
 
 	// add specific units to monitor if any
-	for _, unit := range jb.config.Units {
-		if err = jb.journal.AddMatch(sdjournal.SD_JOURNAL_FIELD_SYSTEMD_UNIT + "=" + unit); err != nil {
-			return fmt.Errorf("Filtering unit %s failed: %v", unit, err)
-		}
+	if err = jb.addUnits(); err != nil {
+		return err
 	}
 
 	// seek position

--- a/beater/unit.go
+++ b/beater/unit.go
@@ -1,0 +1,317 @@
+// Copyright 2017 Marcus Heese
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code based on logic from journalctl unit filter. i.e. journalctl -u in
+// the systemd source code.
+// See: https://github.com/systemd/systemd/blob/master/src/journal/journalctl.c#L1410
+// and https://github.com/systemd/systemd/blob/master/src/basic/unit-name.c
+
+package beater
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/danwakefield/fnmatch" // port of c function fnmatch to pure go
+)
+
+const (
+	unitNameMax      = 256
+	globChars        = "*?["
+	uppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	lowercaseLetters = "abcdefghijklmnopqrstuvwxyz"
+	letters          = lowercaseLetters + uppercaseLetters
+	digits           = "0123456789"
+	validChars       = digits + letters + ":-_.\\"
+	validCharsWithAt = "@" + validChars
+	validCharsGlob   = validCharsWithAt + "[]!-*?"
+)
+
+var systemUnits = []string{
+	"_SYSTEMD_UNIT",
+	"COREDUMP_UNIT",
+	"UNIT",
+	"OBJECT_SYSTEMD_UNIT",
+	"_SYSTEMD_SLICE",
+}
+
+var unitTypes = []string{
+	".service",
+	".socket",
+	".target",
+	".device",
+	".mount",
+	".automount",
+	".swap",
+	".target",
+	".path",
+	".timer",
+	".snapshot",
+	".slice",
+	".scope",
+}
+
+// Add units to monitor
+func (jb *Journalbeat) addUnits() error {
+	var patterns []string
+
+	// add specific units to monitor if any
+	for _, unit := range jb.config.Units {
+		unit, err := unitNameMangle(unit, ".service")
+		if err != nil {
+			return fmt.Errorf("Filtering unit %s failed: %v", unit, err)
+		}
+
+		if stringIsGlob(unit) {
+			patterns = append(patterns, unit)
+		} else {
+			if err = jb.addMatchesForUnit(unit); err != nil {
+				return fmt.Errorf("Filtering unit %s failed: %v", unit, err)
+			}
+		}
+	}
+
+	// Now add glob pattern matches if/any
+	if len(patterns) > 0 {
+		var units []string
+		units = jb.getPossibleUnits(systemUnits, patterns)
+		for _, unit := range units {
+			if err := jb.addMatchesForUnit(unit); err != nil {
+				return fmt.Errorf("Filtering unit %s failed: %v", unit, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// See: https://github.com/systemd/systemd/blob/master/src/shared/logs-show.c#L1114
+func (jb *Journalbeat) addMatchesForUnit(unit string) error {
+	// Wrap AddMatch/AddDisjunction with function literal to avoid repeated checks against err.
+	var err error
+	AddMatch := func(s string) {
+		if err == nil {
+			err = jb.journal.AddMatch(s)
+		}
+	}
+
+	AddDisjunction := func() {
+		if err == nil {
+			err = jb.journal.AddDisjunction()
+		}
+	}
+
+	// Look for messages from the service itself
+	AddMatch("_SYSTEMD_UNIT=" + unit)
+
+	// Look for coredumps of the service
+	AddDisjunction()
+	AddMatch("MESSAGE_ID=fc2e22bc6ee647b6b90729ab34a250b1")
+	AddMatch("_UID=0")
+	AddMatch("COREDUMP_UNIT=" + unit)
+
+	// Look for messages from PID 1 about this service
+	AddDisjunction()
+	AddMatch("_PID=1")
+	AddMatch("UNIT=" + unit)
+
+	// Look for messages from authorized daemons about this service
+	AddDisjunction()
+	AddMatch("_UID=0")
+	AddMatch("OBJECT_SYSTEMD_UNIT=" + unit)
+
+	// Show all messages belonging to a slice
+	if err == nil && strings.HasSuffix(unit, ".slice") {
+		AddDisjunction()
+		AddMatch("_SYSTEMD_SLICE=" + unit)
+	}
+
+	AddDisjunction()
+	return err
+}
+
+//  Convert a string to a unit name. /dev/blah is converted to dev-blah.device,
+//  /blah/blah is converted to blah-blah.mount, anything else is left alone,
+//  except that "suffix" is appended if a valid unit suffix is not present.
+
+//  If allowGlobs, globs characters are preserved. Otherwise, they are escaped.
+func unitNameMangle(name, suffix string) (string, error) {
+	// Can't be empty or begin with a dot
+	if len(name) == 0 || name[0] == '.' {
+		return "", errors.New("unit name can't be empty or begin with a dot")
+	}
+
+	if !unitSuffixIsValid(suffix) {
+		return "", errors.New("unit name has an invalid suffix")
+	}
+
+	// already a fully valid unit name?
+	if unitNameIsValid(name) {
+		return name, nil
+	}
+
+	// Already a fully valid globbing expression? If so, no mangling is necessary either...
+	if stringIsGlob(name) && inCharset(name, validCharsGlob) {
+		return name, nil
+	}
+
+	if isDevicePath(name) {
+		// chop off path and put .device on the end
+		return path.Base(path.Clean(name)) + "device", nil
+	}
+
+	if pathIsAbsolute(name) {
+		// chop path and put .mount on the end
+		return path.Base(path.Clean(name)) + ".mount", nil
+	}
+
+	name = doEscapeMangle(name)
+
+	// Append a suffix if it doesn't have any, but only if this is not a glob,
+	// so that we can allow "foo.*" as a valid glob.
+	if !stringIsGlob(name) && !strings.ContainsAny(name, ".") {
+		return name + suffix, nil
+	}
+
+	return name, nil
+}
+
+// Mangle the unit name.
+func doEscapeMangle(name string) string {
+	var mangled string
+	for _, r := range name {
+		if r == '/' {
+			mangled += "-"
+		} else if !strings.ContainsRune(validChars, r) {
+			mangled += "\\x" + strconv.FormatInt(int64(r), 16)
+		} else {
+			mangled += string(r)
+		}
+	}
+	return mangled
+}
+
+// Check if this is a valid systemd unit name
+func unitNameIsValid(name string) bool {
+	if len(name) >= unitNameMax {
+		return false
+	}
+
+	dot := strings.Index(name, ".")
+
+	// Must have a dot (i.e. suffix)
+	if dot == -1 {
+		return false
+	}
+
+	suffix := name[dot:]
+
+	// Must end with a valid suffix
+	if !unitSuffixIsValid(suffix) {
+		return false
+	}
+
+	// name must only consist of characters from validChars + "@"
+	if !inCharset(name, validCharsWithAt) {
+		return false
+	}
+
+	at := strings.Index(name, "@")
+
+	// Can't start with '@'
+	if at == 0 {
+		return false
+	}
+
+	// Plain unit (not a template or instance) or a template or instance
+	if at == -1 || at > 0 && dot >= at+1 {
+		return true
+	}
+
+	return false
+}
+
+func (jb *Journalbeat) getPossibleUnits(fields, patterns []string) []string {
+	var found []string
+	var possibles []string
+
+	for _, field := range fields {
+		var vals, err = jb.journal.GetUniqueValues(field)
+		if err != nil {
+			continue
+		}
+
+		// Split at '=' and check against all patterns (actually GetUniqueValues does the '=' split for us)
+		possibles = append(possibles, vals...)
+	}
+
+	// filter whole possibles list against patterns and append matches to found list
+	for _, possible := range possibles {
+		for _, pattern := range patterns {
+			if fnmatch.Match(pattern, possible, fnmatch.FNM_NOESCAPE) {
+				found = append(found, possible)
+				break
+			}
+		}
+	}
+
+	return found
+}
+
+// Check for valid unit name suffix
+func unitSuffixIsValid(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+
+	if name[0] != '.' {
+		return false
+	}
+
+	// Unit type from string
+	for _, unit := range unitTypes {
+		if strings.HasSuffix(name, unit) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func inCharset(s, charset string) bool {
+	for _, char := range s {
+		if !strings.Contains(charset, string(char)) {
+			return false
+		}
+	}
+	return true
+}
+
+// Returns true on paths that refer to a device, either in sysfs or in /dev
+func isDevicePath(path string) bool {
+	return strings.HasPrefix(path, "/dev/") || strings.HasPrefix(path, "/sys/")
+}
+
+// Absolute paths begin with a slash
+func pathIsAbsolute(path string) bool {
+	return path[0] == '/'
+}
+
+// Return true if the provided string contains any glob chars
+func stringIsGlob(name string) bool {
+	return strings.ContainsAny(name, globChars)
+}

--- a/vendor/github.com/danwakefield/fnmatch/LICENSE
+++ b/vendor/github.com/danwakefield/fnmatch/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2016, Daniel Wakefield
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/danwakefield/fnmatch/README.md
+++ b/vendor/github.com/danwakefield/fnmatch/README.md
@@ -1,0 +1,4 @@
+# fnmatch
+Updated clone of kballards golang fnmatch gist (https://gist.github.com/kballard/272720)
+
+

--- a/vendor/github.com/danwakefield/fnmatch/fnmatch.go
+++ b/vendor/github.com/danwakefield/fnmatch/fnmatch.go
@@ -1,0 +1,219 @@
+// Provide string-matching based on fnmatch.3
+package fnmatch
+
+// There are a few issues that I believe to be bugs, but this implementation is
+// based as closely as possible on BSD fnmatch. These bugs are present in the
+// source of BSD fnmatch, and so are replicated here. The issues are as follows:
+//
+// * FNM_PERIOD is no longer observed after the first * in a pattern
+//   This only applies to matches done with FNM_PATHNAME as well
+// * FNM_PERIOD doesn't apply to ranges. According to the documentation,
+//   a period must be matched explicitly, but a range will match it too
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	FNM_NOESCAPE = (1 << iota)
+	FNM_PATHNAME
+	FNM_PERIOD
+
+	FNM_LEADING_DIR
+	FNM_CASEFOLD
+
+	FNM_IGNORECASE = FNM_CASEFOLD
+	FNM_FILE_NAME  = FNM_PATHNAME
+)
+
+func unpackRune(str *string) rune {
+	rune, size := utf8.DecodeRuneInString(*str)
+	*str = (*str)[size:]
+	return rune
+}
+
+// Matches the pattern against the string, with the given flags,
+// and returns true if the match is successful.
+// This function should match fnmatch.3 as closely as possible.
+func Match(pattern, s string, flags int) bool {
+	// The implementation for this function was patterned after the BSD fnmatch.c
+	// source found at http://src.gnu-darwin.org/src/contrib/csup/fnmatch.c.html
+	noescape := (flags&FNM_NOESCAPE != 0)
+	pathname := (flags&FNM_PATHNAME != 0)
+	period := (flags&FNM_PERIOD != 0)
+	leadingdir := (flags&FNM_LEADING_DIR != 0)
+	casefold := (flags&FNM_CASEFOLD != 0)
+	// the following is some bookkeeping that the original fnmatch.c implementation did not do
+	// We are forced to do this because we're not keeping indexes into C strings but rather
+	// processing utf8-encoded strings. Use a custom unpacker to maintain our state for us
+	sAtStart := true
+	sLastAtStart := true
+	sLastSlash := false
+	sLastUnpacked := rune(0)
+	unpackS := func() rune {
+		sLastSlash = (sLastUnpacked == '/')
+		sLastUnpacked = unpackRune(&s)
+		sLastAtStart = sAtStart
+		sAtStart = false
+		return sLastUnpacked
+	}
+	for len(pattern) > 0 {
+		c := unpackRune(&pattern)
+		switch c {
+		case '?':
+			if len(s) == 0 {
+				return false
+			}
+			sc := unpackS()
+			if pathname && sc == '/' {
+				return false
+			}
+			if period && sc == '.' && (sLastAtStart || (pathname && sLastSlash)) {
+				return false
+			}
+		case '*':
+			// collapse multiple *'s
+			// don't use unpackRune here, the only char we care to detect is ASCII
+			for len(pattern) > 0 && pattern[0] == '*' {
+				pattern = pattern[1:]
+			}
+			if period && s[0] == '.' && (sAtStart || (pathname && sLastUnpacked == '/')) {
+				return false
+			}
+			// optimize for patterns with * at end or before /
+			if len(pattern) == 0 {
+				if pathname {
+					return leadingdir || (strchr(s, '/') == -1)
+				} else {
+					return true
+				}
+				return !(pathname && strchr(s, '/') >= 0)
+			} else if pathname && pattern[0] == '/' {
+				offset := strchr(s, '/')
+				if offset == -1 {
+					return false
+				} else {
+					// we already know our pattern and string have a /, skip past it
+					s = s[offset:] // use unpackS here to maintain our bookkeeping state
+					unpackS()
+					pattern = pattern[1:] // we know / is one byte long
+					break
+				}
+			}
+			// general case, recurse
+			for test := s; len(test) > 0; unpackRune(&test) {
+				// I believe the (flags &^ FNM_PERIOD) is a bug when FNM_PATHNAME is specified
+				// but this follows exactly from how fnmatch.c implements it
+				if Match(pattern, test, (flags &^ FNM_PERIOD)) {
+					return true
+				} else if pathname && test[0] == '/' {
+					break
+				}
+			}
+			return false
+		case '[':
+			if len(s) == 0 {
+				return false
+			}
+			if pathname && s[0] == '/' {
+				return false
+			}
+			sc := unpackS()
+			if !rangematch(&pattern, sc, flags) {
+				return false
+			}
+		case '\\':
+			if !noescape {
+				if len(pattern) > 0 {
+					c = unpackRune(&pattern)
+				}
+			}
+			fallthrough
+		default:
+			if len(s) == 0 {
+				return false
+			}
+			sc := unpackS()
+			switch {
+			case sc == c:
+			case casefold && unicode.ToLower(sc) == unicode.ToLower(c):
+			default:
+				return false
+			}
+		}
+	}
+	return len(s) == 0 || (leadingdir && s[0] == '/')
+}
+
+func rangematch(pattern *string, test rune, flags int) bool {
+	if len(*pattern) == 0 {
+		return false
+	}
+	casefold := (flags&FNM_CASEFOLD != 0)
+	noescape := (flags&FNM_NOESCAPE != 0)
+	if casefold {
+		test = unicode.ToLower(test)
+	}
+	var negate, matched bool
+	if (*pattern)[0] == '^' || (*pattern)[0] == '!' {
+		negate = true
+		(*pattern) = (*pattern)[1:]
+	}
+	for !matched && len(*pattern) > 1 && (*pattern)[0] != ']' {
+		c := unpackRune(pattern)
+		if !noescape && c == '\\' {
+			if len(*pattern) > 1 {
+				c = unpackRune(pattern)
+			} else {
+				return false
+			}
+		}
+		if casefold {
+			c = unicode.ToLower(c)
+		}
+		if (*pattern)[0] == '-' && len(*pattern) > 1 && (*pattern)[1] != ']' {
+			unpackRune(pattern) // skip the -
+			c2 := unpackRune(pattern)
+			if !noescape && c2 == '\\' {
+				if len(*pattern) > 0 {
+					c2 = unpackRune(pattern)
+				} else {
+					return false
+				}
+			}
+			if casefold {
+				c2 = unicode.ToLower(c2)
+			}
+			// this really should be more intelligent, but it looks like
+			// fnmatch.c does simple int comparisons, therefore we will as well
+			if c <= test && test <= c2 {
+				matched = true
+			}
+		} else if c == test {
+			matched = true
+		}
+	}
+	// skip past the rest of the pattern
+	ok := false
+	for !ok && len(*pattern) > 0 {
+		c := unpackRune(pattern)
+		if c == '\\' && len(*pattern) > 0 {
+			unpackRune(pattern)
+		} else if c == ']' {
+			ok = true
+		}
+	}
+	return ok && matched != negate
+}
+
+// define strchr because strings.Index() seems a bit overkill
+// returns the index of c in s, or -1 if there is no match
+func strchr(s string, c rune) int {
+	for i, sc := range s {
+		if sc == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -529,5 +529,5 @@
 			"revisionTime": "2017-04-07T17:21:22Z"
 		}
 	],
-	"rootPath": "github.com/hookenz/journalbeat"
+	"rootPath": "github.com/mheese/journalbeat"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,6 +21,12 @@
 			"revisionTime": "2017-04-20T17:29:56Z"
 		},
 		{
+			"checksumSHA1": "d/czTNq3bacK85PFEKcHvW6aR80=",
+			"path": "github.com/danwakefield/fnmatch",
+			"revision": "cbb64ac3d964b81592e64f957ad53df015803288",
+			"revisionTime": "2016-04-03T17:12:40Z"
+		},
+		{
 			"checksumSHA1": "7UT+dVVfOn8IA79ITFiGNMb2c/4=",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "782f4967f2dc4564575ca782fe2d04090b5faca8",
@@ -523,5 +529,5 @@
 			"revisionTime": "2017-04-07T17:21:22Z"
 		}
 	],
-	"rootPath": "github.com/mheese/journalbeat"
+	"rootPath": "github.com/hookenz/journalbeat"
 }


### PR DESCRIPTION
This fixes issue:  https://github.com/mheese/journalbeat/issues/90

So that the configuration item `units = [ ... ]` found in `journalbeat.yml` will match what journalctl -u does.

See `man journalctl`.  Specifically:

```
-u, --unit=UNIT|PATTERN
           Show messages for the specified systemd unit UNIT (such as a service unit), or for any of the units matched by PATTERN. If a pattern is specified, a list
           of unit names found in the journal is compared with the specified pattern and all that match are used. For each unit name, a match is added for messages
           from the unit ("_SYSTEMD_UNIT=UNIT"), along with additional matches for messages from systemd and messages about coredumps for the specified unit.
```