### PR TITLE
fixed race in journalbeat.Stop (#97 #98)

### DIFF
--- a/beater/journalbeat.go
+++ b/beater/journalbeat.go
@@ -184,6 +184,8 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 func (jb *Journalbeat) Run(b *beat.Beat) error {
 	logp.Info("Journalbeat is running!")
 	defer func() {
+		_ = jb.client.Close()
+		close(jb.completed)
 		_ = jb.journal.Close()
 		close(jb.cursorChan)
 		close(jb.pending)
@@ -235,6 +237,4 @@ func (jb *Journalbeat) Run(b *beat.Beat) error {
 func (jb *Journalbeat) Stop() {
 	logp.Info("Stopping Journalbeat")
 	close(jb.done)
-	_ = jb.client.Close()
-	close(jb.completed)
 }


### PR DESCRIPTION
Moving cleanup code from Stop to Run avoids concurrent data access.

as discussed in #98