### PR TITLE
Upgrade base docker image to stretch-slim

### DIFF
--- a/docker/dockerfile.release
+++ b/docker/dockerfile.release
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch-slim
 MAINTAINER mbrooks
 
 RUN apt-get update && \


### PR DESCRIPTION
This allows journalbeat docker image to work on the last
CoreOS update (1465.6).

See mheese/journalbeat#106 for details.