### PR TITLE
Add test to container build before tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,12 @@ build/Dockerfile:
 	cp docker/dockerfile.release build/Dockerfile
 
 #
+# Copy the entrypoint for release to the build directory
+#
+build/entrypoint:
+	cp docker/entrypoint.sh build/entrypoint
+
+#
 # Copy the default journalbeat.yml for release to the build directory
 #
 build/journalbeat.yml:
@@ -66,16 +72,23 @@ build/journalbeat.yml:
 #
 # docker tag the image
 #
-docker-tag: docker-build
+docker-tag: docker-test
 	echo $(TAGS) | xargs -n 1 docker tag $(IMAGE_NAME)
 .PHONY: docker-tag
 
 #
 # docker build the image
 #
-docker-build: build build/Dockerfile build/journalbeat.yml
+docker-build: build build/Dockerfile build/journalbeat.yml build/entrypoint
 	cd build && docker build -t $(IMAGE_NAME) .
 .PHONY: docker-build
+
+#
+# test the built docker image
+#
+docker-test: docker-build
+	cd build && docker run --rm -e LOGSTASH_HOST=localhost -t $(IMAGE_NAME) -configtest
+.PHONY: docker-test
 
 #
 # docker push all tags

--- a/docker/dockerfile.release
+++ b/docker/dockerfile.release
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /data
-WORKDIR /
-COPY journalbeat journalbeat.yml ./
+COPY journalbeat journalbeat.yml entrypoint /
+RUN chmod 0755 /entrypoint /journalbeat
 
-CMD ["./journalbeat", "-e", "-c", "journalbeat.yml"]
+ENTRYPOINT ["/entrypoint"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+if [[ -z $1 ]] || [[ ${1:0:1} == '-' ]] ; then
+  exec  /journalbeat -e "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
These commits add a new recipe and the support for it (entrypoint etc) to allow testing the container before pushing it to the repo.