### PR TITLE
added code to remove ansi values from color coded output

### DIFF
--- a/beater/convert.go
+++ b/beater/convert.go
@@ -17,6 +17,7 @@ package beater
 import (
 	"strconv"
 	"strings"
+        "regexp"
 
 	"github.com/coreos/go-systemd/sdjournal"
 	"github.com/elastic/beats/libbeat/common"
@@ -45,11 +46,15 @@ func MapStrFromJournalEntry(ev *sdjournal.JournalEntry, cleanKeys bool, convertT
 
 	// range over the JournalEntry Fields and convert to the common.MapStr
 	for k, v := range ev.Fields {
+		var re = regexp.MustCompile(`\x1b\[[0-9;]*[mG]`)
+		// if str, ok := nv.(string); ok {
+		newv := re.ReplaceAllString(v, ``)
+		// }
 		nk := makeNewKey(k, cleanKeys)
-		nv := makeNewValue(v, convertToNumbers)
+		nv := makeNewValue(newv, convertToNumbers)
 		// message Field should be on the top level of the event
 		if nk == "message" {
-			m[nk] = nv
+		        m[nk] = nv
 			continue
 		}
 		target[nk] = nv


### PR DESCRIPTION
There's probably a better way to do this, as I am no Golang expert by any means.

But I was running into a problem where I was getting values in the Elasticsearch message, such as `[32m`, `[37m`, and `[0m`.  These turned out to be due to ANSI values.  They were annoying.  I'm looking at the code that generates them as well (Python logger in this particular case), but I was able to track down this section of code first.

It probably should be a command line argument or something.  But this was a first step.

Issue: https://github.com/mheese/journalbeat/issues/134