### PR TITLE
Fix publishing of pending events on start

### DIFF
--- a/beater/journalbeat.go
+++ b/beater/journalbeat.go
@@ -136,6 +136,9 @@ func (jb *Journalbeat) publishPending() error {
 
 	logp.Info("Loaded %d events, trying to publish", len(pending))
 	for cursor, event := range pending {
+		// We need to convert the timestamp back to the correct type before trying to publish
+		timestamp, _ := time.Parse(time.RFC3339, event["@timestamp"].(string))
+		event["@timestamp"] = common.Time(timestamp)
 		ref := &eventReference{cursor, event}
 		jb.pending <- ref
 		refs = append(refs, ref)


### PR DESCRIPTION
Fixes #72. 

It looks like after parsing the pending_queue JSON file, the `@timestamp` parameter in the event was still a string. It is properly converted to a `common.Time` when reading from the journal directly but not when reading from the pending_queue.

This pull request converts the `@timestamp` into the correct type before it is queued again for publishing.

Let me know if this looks good, I'm not that familiar with Go.