### PR TITLE
Add example systemd service file

### DIFF
--- a/etc/journalbeat.service
+++ b/etc/journalbeat.service
@@ -1,0 +1,51 @@
+# Example systemd unit file.
+# Add this file to "/etc/systemd/system/journalbeat.service" The `ExecStart`
+# should be changed point at the correct binary path, configuration options.
+
+[Unit]
+Description = journalbeat service
+Documentation = https://github.com/mheese/journalbeat/blob/master/README.md
+Wants = network-online.target
+After = network-online.target
+
+[Service]
+User = root
+Group = root
+Type = simple
+
+# Go environment file. This should be setting the GOPATH GOROOT and extend the
+# environment PATH. This is optional and only used when go is not installed
+# into the system path.
+# Example:
+#   export GOROOT=/opt/go1.10.1/go
+#   export GOPATH=${GOROOT}
+#   export PATH=${PATH}:${GOROOT}/bin
+# EnvironmentFile = -/etc/default/go1.10.1
+
+ExecReload = /bin/kill -HUP $MAINPID
+ExecStart = /usr/local/bin/journalbeat -c /etc/journalbeat/journalbeat.yml -path.home /usr/share/journalbeat -path.config /etc/journalbeat -path.data /var/lib/journalbeat -path.logs /var/log/journalbeat
+
+# Set Accounting
+BlockIOAccounting = True
+CPUAccounting = True
+MemoryAccounting = True
+TasksAccounting = True
+PrivateDevices = False
+PrivateNetwork = False
+
+# Set Sandboxing
+PrivateTmp = True
+PrivateUsers = True
+Restart = on-failure
+RestartSec = 2
+
+# This creates a specific slice which all services will operate from
+#  The accounting options give us the ability to see resource usage through
+#  the `systemd-cgtop` command.
+Slice = system.slice
+
+# Give a reasonable amount of time for the server to start up/shut down
+TimeoutSec = 120
+
+[Install]
+WantedBy = multi-user.target


### PR DESCRIPTION
This change adds an example systemd service file to start journalbeat
when systemd is present.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>